### PR TITLE
try 2

### DIFF
--- a/src/symbolic/symbolic_choice_with_memory.ml
+++ b/src/symbolic/symbolic_choice_with_memory.ml
@@ -1,1 +1,5 @@
 include Symbolic_choice.Make (Thread_with_memory)
+
+let lift_mem (mem_op : 'a Symbolic_choice_without_memory.t) : 'a t =
+  Symbolic_choice.CoreImpl.State.project_state Thread_with_memory.project
+    Thread_with_memory.restore mem_op

--- a/src/symbolic/thread_with_memory.ml
+++ b/src/symbolic/thread_with_memory.ml
@@ -1,1 +1,25 @@
 include Thread.Make (Symbolic_memory)
+
+let project (th : t) : Thread_without_memory.t * _ =
+  let projected =
+    { Thread_without_memory.symbols = th.symbols
+    ; symbol_set = th.symbol_set
+    ; pc = th.pc
+    ; memories = ()
+    ; tables = th.tables
+    ; globals = th.globals
+    ; breadcrumbs = th.breadcrumbs
+    }
+  in
+  let backup = th.memories in
+  (projected, backup)
+
+let restore backup th =
+  { symbols = th.Thread_without_memory.symbols
+  ; symbol_set = th.symbol_set
+  ; pc = th.pc
+  ; memories = backup
+  ; tables = th.tables
+  ; globals = th.globals
+  ; breadcrumbs = th.breadcrumbs
+  }


### PR DESCRIPTION
It compiles \o/

The S signature cannot be put as an output of the Make functor itself, but should be included in the mli of the two instantiated symbolic_choice_with(out)-memory.

Enjoy the weekend!